### PR TITLE
Fixes, add mocking + new deployment method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-hivemind",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -317,6 +317,17 @@
         "uuid": "3.0.1",
         "xml2js": "0.4.17",
         "xmlbuilder": "4.2.1"
+      }
+    },
+    "aws-sdk-mock": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-1.7.0.tgz",
+      "integrity": "sha1-dpizuoL0k/cf8GCuISPNCAathnY=",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "2.104.0",
+        "sinon": "1.17.7",
+        "traverse": "0.6.6"
       }
     },
     "babel-code-frame": {
@@ -761,6 +772,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+    },
+    "batch": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
     },
     "binary-extensions": {
       "version": "1.10.0",
@@ -1415,6 +1431,33 @@
         "for-in": "1.0.2"
       }
     },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
+    },
+    "fs-extra": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
+      "integrity": "sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=",
+      "requires": {
+        "jsonfile": "1.0.1",
+        "mkdirp": "0.3.5",
+        "ncp": "0.4.2",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1924,6 +1967,11 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
+      "integrity": "sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2024,6 +2072,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "loose-envify": {
@@ -2253,16 +2307,23 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mock-aws-s3": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mock-aws-s3/-/mock-aws-s3-2.6.0.tgz",
+      "integrity": "sha512-eZVouXl5EKoXSDX/TRyVsIg9MXBnlL60iPBpF5XPOEMPtpftLc57nLDjqtNkWyRhTjn3jWc/oP0TaAgXv5bYKA==",
+      "requires": {
+        "fs-extra": "0.6.4",
+        "underscore": "1.8.3"
       }
     },
     "ms": {
@@ -2282,6 +2343,11 @@
         "arrify": "1.0.1",
         "minimatch": "3.0.4"
       }
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -2488,6 +2554,15 @@
         "pify": "2.3.0"
       }
     },
+    "persist-store": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/persist-store/-/persist-store-2.0.1.tgz",
+      "integrity": "sha1-N0sP6albXQYANZZOj8zCoPIbg0s=",
+      "requires": {
+        "mkdirp": "0.5.1",
+        "s3-lambda": "5.1.8"
+      }
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2578,6 +2653,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -2858,10 +2938,32 @@
         "signal-exit": "3.0.2"
       }
     },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+    },
+    "s3-lambda": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/s3-lambda/-/s3-lambda-5.1.8.tgz",
+      "integrity": "sha1-ugU7WtEXLaKom6sVX37JBGuftU8=",
+      "requires": {
+        "aws-sdk": "2.104.0",
+        "batch": "0.5.3",
+        "mock-aws-s3": "2.6.0",
+        "progress": "1.1.8"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
     },
     "sax": {
       "version": "1.2.1",
@@ -2909,6 +3011,18 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -2988,14 +3102,6 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3004,6 +3110,14 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -3174,6 +3288,12 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -3197,6 +3317,11 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unique-string": {
       "version": "1.0.0",
@@ -3292,6 +3417,23 @@
       "dev": true,
       "requires": {
         "prepend-http": "1.0.4"
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   "homepage": "https://github.com/littlstar/hivemind#readme",
   "dependencies": {
     "aws-sdk": "^2.104.0",
+    "persist-store": "^2.0.1",
     "through2": "^2.0.3",
     "yazl": "^2.4.2"
   },
   "devDependencies": {
-    "ava": "^0.22.0"
+    "ava": "^0.22.0",
+    "aws-sdk-mock": "^1.7.0"
   }
 }


### PR DESCRIPTION
This PR adds the beginning of a new deploy method: functions. Rather than having to create files or ZIP files before, you can pass a Javascript function and that function will be deployed. 

The caveat to that is that the function cannot require anything since node_modules is not packaged. 

In addition, there are a few small fixes and I added mocking to be able to test Hivemind without hitting AWS endpoints